### PR TITLE
Ethdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "@types/node": "^16.7.13",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "bls-wallet-clients": "0.8.2-77f1638",
+    "bls-wallet-clients": "0.8.3",
     "eslint": "^8.21.0",
+    "ethdk": "^0.0.0-beta.4",
     "ethers": "^5.7.2",
     "phosphor-react": "^1.4.1",
     "qrcode.react": "^3.1.0",
@@ -29,7 +30,7 @@
     "zustand": "^4.1.1"
   },
   "scripts": {
-    "start": "react-app-rewired start",
+    "start": "PORT=3001 react-app-rewired start",
     "start-no-source": "GENERATE_SOURCEMAP=false react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import Send from './components/send';
 import { ToastContext } from './ToastContext';
 import Balance from './components/balance';
 import { getAddress } from './controllers/TransactionController';
-import { setAccount, setAccountAndPK, useLocalStore } from './store';
+import { setAddress, setAddressAndPK, useLocalStore } from './store';
 import { BLS_TEAM_PK } from './constants';
 
 function useQuery() {
@@ -22,33 +22,33 @@ function useQuery() {
 function App() {
   const { message, setMessage } = useContext(ToastContext);
   const privateKey = useLocalStore((state) => state.privateKey);
-  const account = useLocalStore((state) => state.account);
+  const address = useLocalStore((state) => state.address);
 
   const query = useQuery();
 
   useEffect(() => {
     const getAccountDetails = async () => {
       if (query.get('wallet') === 'bls-team' && privateKey !== BLS_TEAM_PK) {
-        const address = await getAddress(BLS_TEAM_PK);
-        setAccountAndPK(BLS_TEAM_PK, address);
+        const newAddress = await getAddress(BLS_TEAM_PK);
+        setAddressAndPK(BLS_TEAM_PK, newAddress);
         return;
       }
 
       if (!privateKey) {
         const pk = await BlsAccount.generatePrivateKey();
-        const address = await getAddress(pk);
-        setAccountAndPK(pk, address);
+        const newAddress = await getAddress(pk);
+        setAddressAndPK(pk, newAddress);
         return;
       }
 
-      const address = await getAddress();
-      if (account !== address) {
-        setAccount(address);
+      const newAddress = await getAddress();
+      if (newAddress !== address) {
+        setAddress(address);
       }
     };
 
     getAccountDetails();
-  }, [setAccount]);
+  }, [setAddress]);
 
   useEffect(() => {
     if (message) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,7 @@ import Address from './components/address';
 import Send from './components/send';
 import { ToastContext } from './ToastContext';
 import Balance from './components/balance';
-import { getAddress } from './controllers/TransactionController';
-import { setAddress, setAddressAndPK, useLocalStore } from './store';
+import { setPrivateKey, useLocalStore } from './store';
 import { BLS_TEAM_PK } from './constants';
 
 function useQuery() {
@@ -22,33 +21,25 @@ function useQuery() {
 function App() {
   const { message, setMessage } = useContext(ToastContext);
   const privateKey = useLocalStore((state) => state.privateKey);
-  const address = useLocalStore((state) => state.address);
 
   const query = useQuery();
+  const isTeamWallet = query.get('wallet') === 'bls-team';
 
   useEffect(() => {
     const getAccountDetails = async () => {
-      if (query.get('wallet') === 'bls-team' && privateKey !== BLS_TEAM_PK) {
-        const newAddress = await getAddress(BLS_TEAM_PK);
-        setAddressAndPK(BLS_TEAM_PK, newAddress);
+      if (isTeamWallet && privateKey !== BLS_TEAM_PK) {
+        setPrivateKey(BLS_TEAM_PK);
         return;
       }
 
       if (!privateKey) {
         const pk = await BlsAccount.generatePrivateKey();
-        const newAddress = await getAddress(pk);
-        setAddressAndPK(pk, newAddress);
-        return;
-      }
-
-      const newAddress = await getAddress();
-      if (newAddress !== address) {
-        setAddress(address);
+        setPrivateKey(pk);
       }
     };
 
     getAccountDetails();
-  }, [setAddress]);
+  }, [isTeamWallet, privateKey, setPrivateKey]);
 
   useEffect(() => {
     if (message) {

--- a/src/components/address.tsx
+++ b/src/components/address.tsx
@@ -5,16 +5,16 @@ import { useLocalStore } from '../store';
 import TextAddress from './textAddress';
 
 function Address() {
-  const account = useLocalStore((state) => state.account);
+  const address = useLocalStore((state) => state.address);
 
   return (
     <div className="flex items-center flex-col">
-      {account
+      {address
         && (
           <div className="p-6 bg-white items-center flex flex-col">
-            <QRCodeSVG value={account} size={256} />
+            <QRCodeSVG value={address} size={256} />
             <div className="mt-4">
-              <TextAddress address={account} />
+              <TextAddress address={address} />
             </div>
           </div>
         )}

--- a/src/components/balance.tsx
+++ b/src/components/balance.tsx
@@ -6,8 +6,8 @@ import { useOnBlock } from '../hooks';
 
 function Balance() {
   const [balance, setBalance] = useState('');
-  const { account, network } = useLocalStore((state) => ({
-    account: state.account,
+  const { address, network } = useLocalStore((state) => ({
+    address: state.address,
     network: state.network,
   }));
   const provider = useProvider((state) => state.provider);
@@ -15,7 +15,7 @@ function Balance() {
   useEffect(() => {
     // Get balance when account is first set or changes
     getBalance();
-  }, [account, network]);
+  }, [address, network]);
 
   useOnBlock(provider, () => {
     // Get balance on a new block
@@ -23,10 +23,10 @@ function Balance() {
   });
 
   const getBalance = async () => {
-    if (!account) {
+    if (!address) {
       return;
     }
-    const newBalance = await provider.getBalance(account);
+    const newBalance = await provider.getBalance(address);
     const formattedBalance = ethers.utils.formatEther(newBalance);
 
     if (formattedBalance !== balance) {

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -5,9 +5,8 @@ import FormControl from '@mui/material/FormControl';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import { PenNibStraight } from 'phosphor-react';
 
-import { getAddress } from '../controllers/TransactionController';
 import { NETWORKS } from '../constants';
-import { setAddress, setNetwork, useLocalStore } from '../store';
+import { setNetwork, useLocalStore } from '../store';
 import Recovery from './recovery';
 
 function Header() {
@@ -15,8 +14,6 @@ function Header() {
 
   const handleChange = async (event: SelectChangeEvent) => {
     setNetwork(event.target.value);
-    const address = await getAddress();
-    setAddress(address);
   };
 
   return (

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -7,7 +7,7 @@ import { PenNibStraight } from 'phosphor-react';
 
 import { getAddress } from '../controllers/TransactionController';
 import { NETWORKS } from '../constants';
-import { setAccount, setNetwork, useLocalStore } from '../store';
+import { setAddress, setNetwork, useLocalStore } from '../store';
 import Recovery from './recovery';
 
 function Header() {
@@ -16,7 +16,7 @@ function Header() {
   const handleChange = async (event: SelectChangeEvent) => {
     setNetwork(event.target.value);
     const address = await getAddress();
-    setAccount(address);
+    setAddress(address);
   };
 
   return (

--- a/src/components/recovery.tsx
+++ b/src/components/recovery.tsx
@@ -25,19 +25,19 @@ const style = {
 
 function Recovery() {
   const [open, setOpen] = useState(false);
-  const [address, setAddress] = useState('');
+  const [currAddress, setCurrAddress] = useState('');
   const [salt, setSalt] = useState('');
   const [saltError, setSaltError] = useState(false);
   const { setMessage } = useContext(ToastContext);
-  const { recoverySalt, account } = useLocalStore((state) => ({
+  const { recoverySalt, address } = useLocalStore((state) => ({
     recoverySalt: state.recoverySalt[state.network],
-    account: state.account,
+    address: state.address,
   }));
 
   const setRecovery = async () => {
-    await createRecoveryHash(address, salt);
+    await createRecoveryHash(currAddress, salt);
     setRecoverySalt(salt);
-    setAddress('');
+    setCurrAddress('');
     setSalt('');
     setMessage('Transaction successful');
   };
@@ -69,8 +69,8 @@ function Recovery() {
               className="w-52"
               variant="filled"
               label="Recovery address"
-              value={address}
-              onChange={(event) => setAddress(event.target.value)}
+              value={currAddress}
+              onChange={(event) => setCurrAddress(event.target.value)}
             />
             <TextField
               error={saltError}
@@ -84,7 +84,7 @@ function Recovery() {
             <Button
               variant="contained"
               onClick={setRecovery}
-              disabled={!salt || !address || saltError}
+              disabled={!salt || !currAddress || saltError}
             >
               {recoverySalt ? 'Update' : 'Set'}
               {' '}
@@ -95,7 +95,7 @@ function Recovery() {
                 <p>To recover this wallet, copy the below info to your Quill wallet</p>
                 <div className="flex flex-row w-64 items-center">
                   <p className="mr-auto">Wallet address:</p>
-                  <TextAddress address={account} />
+                  <TextAddress address={address} />
                 </div>
                 <div className="flex flex-row w-64 items-center">
                   <p className="mr-auto">Salt:</p>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,37 +1,12 @@
-type NetworkConfigType = {
-  name: string,
-  chainId: string,
-  rpcUrl: string,
-  aggregatorUrl: string,
-  verificationGateway: string,
-};
+import { networks } from 'ethdk';
+import { BlsNetwork } from 'ethdk/dist/src/interfaces/Network';
 
 type NetworksType = {
-  [key: string]: NetworkConfigType,
+  [key: string]: BlsNetwork,
 };
 
 export const NETWORKS: NetworksType = {
-  localhost: {
-    name: 'localhost',
-    chainId: '31337',
-    rpcUrl: 'http://localhost:8545',
-    aggregatorUrl: 'http://localhost:3000',
-    verificationGateway: '0x689A095B4507Bfa302eef8551F90fB322B3451c6',
-  },
-  arbitrumGoerli: {
-    chainId: '421613',
-    name: 'Arbitrum Goerli',
-    rpcUrl: process.env.REACT_APP_ARBITRUM_GOERLI_RPC ?? '',
-    aggregatorUrl: process.env.REACT_APP_ARBITRUM_GOERLI_AGG ?? 'https://arbitrum-goerli.blswallet.org',
-    verificationGateway: '0xae7DF242c589D479A5cF8fEA681736e0E0Bb1FB9',
-  },
-  optimismGoerli: {
-    name: 'Optimism Goerli',
-    chainId: '420',
-    rpcUrl: process.env.REACT_APP_OPTIMISM_GOERLI_RPC ?? '',
-    aggregatorUrl: process.env.REACT_APP_OPTIMISM_GOERLI_AGG ?? 'https://optimism-goerli.blswallet.org',
-    verificationGateway: '0x643468269B044bA84D3F2190F601E3579d3236BB',
-  },
+  localhost: networks.BLS_NETWORKS.localhost,
 };
 
 export function getNetwork(networkName: string) {
@@ -40,4 +15,4 @@ export function getNetwork(networkName: string) {
 
 export const BLS_TEAM_PK = process.env.REACT_APP_BLS_TEAM_PK ?? '';
 
-export const RPC_POLLING_INTERVAL = 10000;
+export const RPC_POLLING_INTERVAL = 4000;

--- a/src/controllers/TransactionController.ts
+++ b/src/controllers/TransactionController.ts
@@ -17,14 +17,18 @@ function findNetwork() {
   return getNetwork(network);
 }
 
+function getAccount(privateKey?: string) {
+  return createAccount({
+    accountType: 'bls',
+    privateKey: privateKey ?? useLocalStore.getState().privateKey,
+    network: findNetwork(),
+  });
+}
+
 export const sendTransaction = async (
   params: SendTransactionParams[],
 ) => {
-  const account = await createAccount({
-    accountType: 'bls',
-    privateKey: useLocalStore.getState().privateKey,
-  });
-
+  const account = await getAccount();
   const transaction = await account.sendTransaction({
     to: params[0].to,
     value: params[0].value,
@@ -43,18 +47,12 @@ export const getTransactionReceipt = async (hash: string) => {
 };
 
 export const getAddress = async (privateKey?: string) => {
-  const account = await createAccount({
-    accountType: 'bls',
-    privateKey: privateKey ?? useLocalStore.getState().privateKey,
-  });
+  const account = await getAccount(privateKey);
   return account.address;
 };
 
 export const createRecoveryHash = async (recoveryAddress: string, salt: string) => {
-  const account = await createAccount({
-    accountType: 'bls',
-    privateKey: useLocalStore.getState().privateKey,
-  });
+  const account = await getAccount();
   const transaction = await account.setTrustedAccount(
     salt,
     recoveryAddress,

--- a/src/controllers/TransactionController.ts
+++ b/src/controllers/TransactionController.ts
@@ -1,7 +1,7 @@
-import { BlsTransaction, createAccount } from 'ethdk';
+import { BlsTransaction } from 'ethdk';
 
 import { getNetwork } from '../constants';
-import { useLocalStore } from '../store';
+import { useLocalStore, getAccount } from '../store';
 
 export type SendTransactionParams = {
   to: string,
@@ -15,14 +15,6 @@ export type SendTransactionParams = {
 function findNetwork() {
   const { network } = useLocalStore.getState();
   return getNetwork(network);
-}
-
-function getAccount(privateKey?: string) {
-  return createAccount({
-    accountType: 'bls',
-    privateKey: privateKey ?? useLocalStore.getState().privateKey,
-    network: findNetwork(),
-  });
 }
 
 export const sendTransaction = async (
@@ -44,11 +36,6 @@ export const getTransactionReceipt = async (hash: string) => {
   });
   const receipt = await transaction.getTransactionReceipt();
   return receipt;
-};
-
-export const getAddress = async (privateKey?: string) => {
-  const account = await getAccount(privateKey);
-  return account.address;
 };
 
 export const createRecoveryHash = async (recoveryAddress: string, salt: string) => {

--- a/src/controllers/TransactionController.ts
+++ b/src/controllers/TransactionController.ts
@@ -1,7 +1,7 @@
-import { Aggregator, BlsWalletWrapper } from 'bls-wallet-clients';
+import { BlsTransaction, createAccount } from 'ethdk';
 
 import { getNetwork } from '../constants';
-import { useLocalStore, useProvider } from '../store';
+import { useLocalStore } from '../store';
 
 export type SendTransactionParams = {
   to: string,
@@ -20,91 +20,44 @@ function findNetwork() {
 export const sendTransaction = async (
   params: SendTransactionParams[],
 ) => {
-  // TODO: Implement user transaction approval
-  const actions = params.map((tx) => ({
-    ethValue: tx.value ?? '0',
-    contractAddress: tx.to,
-    encodedFunction: tx.data ?? '0x',
-  }));
+  const account = await createAccount({
+    accountType: 'bls',
+    privateKey: useLocalStore.getState().privateKey,
+  });
 
-  const { privateKey } = useLocalStore.getState();
-  const { provider } = useProvider.getState();
-  const wallet = await BlsWalletWrapper.connect(
-    privateKey,
-    findNetwork().verificationGateway,
-    provider,
-  );
+  const transaction = await account.sendTransaction({
+    to: params[0].to,
+    value: params[0].value,
+  });
 
-  const nonce = (
-    await BlsWalletWrapper.Nonce(
-      wallet.PublicKey(),
-      findNetwork().verificationGateway,
-      provider,
-    )
-  ).toString();
-  const bundle = await wallet.sign({ nonce, actions });
-
-  const agg = new Aggregator(findNetwork().aggregatorUrl);
-  const result = await agg.add(bundle);
-
-  if ('failures' in result) {
-    throw new Error(JSON.stringify(result));
-  }
-
-  // Todo: maybe persist known transactions?
-
-  return result.hash;
+  return transaction.hash;
 };
 
 export const getTransactionReceipt = async (hash: string) => {
-  const aggregator = new Aggregator(findNetwork().aggregatorUrl);
-  const bundleReceipt: any = await aggregator.lookupReceipt(hash);
-
-  return (
-    bundleReceipt && {
-      transactionHash: hash,
-      transactionIndex: bundleReceipt.transactionIndex,
-      blockHash: bundleReceipt.blockHash,
-      blockNumber: bundleReceipt.blockNumber,
-      logs: [],
-      cumulativeGasUsed: '0x0',
-      gasUsed: '0x0',
-      status: '0x1',
-      effectiveGasPrice: '0x0',
-    }
-  );
+  const transaction = new BlsTransaction({
+    bundleHash: hash,
+    network: findNetwork(),
+  });
+  const receipt = await transaction.getTransactionReceipt();
+  return receipt;
 };
 
-export const getAddress = async () => {
-  const { privateKey } = useLocalStore.getState();
-  const { provider } = useProvider.getState();
-  return BlsWalletWrapper.Address(
-    privateKey,
-    findNetwork().verificationGateway,
-    provider,
-  );
+export const getAddress = async (privateKey?: string) => {
+  const account = await createAccount({
+    accountType: 'bls',
+    privateKey: privateKey ?? useLocalStore.getState().privateKey,
+  });
+  return account.address;
 };
 
 export const createRecoveryHash = async (recoveryAddress: string, salt: string) => {
-  const { privateKey } = useLocalStore.getState();
-  const { provider } = useProvider.getState();
-  const wallet = await BlsWalletWrapper.connect(
-    privateKey,
-    findNetwork().verificationGateway,
-    provider,
-  );
-
-  const bundle = await wallet.getSetRecoveryHashBundle(
+  const account = await createAccount({
+    accountType: 'bls',
+    privateKey: useLocalStore.getState().privateKey,
+  });
+  const transaction = await account.setTrustedAccount(
     salt,
     recoveryAddress,
   );
-
-  const agg = new Aggregator(findNetwork().aggregatorUrl);
-  const result = await agg.add(bundle);
-
-  if ('failures' in result) {
-    throw new Error(JSON.stringify(result));
-  }
-
-  return result.hash;
+  return transaction.hash;
 };

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,6 +1,7 @@
 import create from 'zustand';
 import { persist } from 'zustand/middleware';
 import { ethers } from 'ethers';
+import { createAccount } from 'ethdk';
 import { getNetwork, RPC_POLLING_INTERVAL } from './constants';
 
 type LocalStoreType = {
@@ -26,13 +27,39 @@ export const useLocalStore = create<LocalStoreType, any>(
   ),
 );
 
-export const setPrivateKey = (privateKey: string) => useLocalStore.setState(() => ({ privateKey }));
+export const setPrivateKey = (privateKey: string) => {
+  const { network } = useLocalStore.getState();
+  updateAccountData(privateKey, network);
+};
 
 export const setNetwork = (network: string) => {
-  useLocalStore.setState(() => ({ network }));
-  updateProvider();
+  const { privateKey } = useLocalStore.getState();
+  updateAccountData(privateKey, network);
 };
-export const setAddress = (address: string) => useLocalStore.setState(() => ({ address }));
+
+export const updateAccountData = async (privateKey: string, network: string) => {
+  const account = await createAccount({
+    accountType: 'bls',
+    privateKey,
+    network: getNetwork(network),
+  });
+  useLocalStore.setState(() => ({
+    network,
+    address: account.address,
+    privateKey,
+  }));
+};
+
+export const getAccount = async () => {
+  const { network, privateKey } = useLocalStore.getState();
+
+  return createAccount({
+    accountType: 'bls',
+    privateKey,
+    network: getNetwork(network),
+  });
+};
+
 export const setRecoverySalt = (hash: string) => {
   const { network, recoverySalt } = useLocalStore.getState();
   const newRecoverySalt = { ...recoverySalt, [network]: hash };
@@ -59,8 +86,4 @@ export const updateProvider = () => {
   useProvider.setState(() => ({
     provider,
   }));
-};
-
-export const setAddressAndPK = (privateKey: string, address: string) => {
-  useLocalStore.setState(() => ({ privateKey, address }));
 };

--- a/src/store.ts
+++ b/src/store.ts
@@ -5,7 +5,7 @@ import { getNetwork, RPC_POLLING_INTERVAL } from './constants';
 
 type LocalStoreType = {
   network: string,
-  account: string,
+  address: string,
   privateKey: string,
   recoverySalt: {
     [key: string]: string,
@@ -16,7 +16,7 @@ export const useLocalStore = create<LocalStoreType, any>(
   persist(
     () => ({
       network: 'localhost',
-      account: '',
+      address: '',
       privateKey: '',
       recoverySalt: {},
     }),
@@ -32,7 +32,7 @@ export const setNetwork = (network: string) => {
   useLocalStore.setState(() => ({ network }));
   updateProvider();
 };
-export const setAccount = (account: string) => useLocalStore.setState(() => ({ account }));
+export const setAddress = (address: string) => useLocalStore.setState(() => ({ address }));
 export const setRecoverySalt = (hash: string) => {
   const { network, recoverySalt } = useLocalStore.getState();
   const newRecoverySalt = { ...recoverySalt, [network]: hash };
@@ -61,6 +61,6 @@ export const updateProvider = () => {
   }));
 };
 
-export const setAccountAndPK = (privateKey: string, account: string) => {
-  useLocalStore.setState(() => ({ privateKey, account }));
+export const setAddressAndPK = (privateKey: string, address: string) => {
+  useLocalStore.setState(() => ({ privateKey, address }));
 };

--- a/src/store.ts
+++ b/src/store.ts
@@ -15,9 +15,9 @@ type LocalStoreType = {
 export const useLocalStore = create<LocalStoreType, any>(
   persist(
     () => ({
-      network: 'arbitrumGoerli',
+      network: 'localhost',
       account: '',
-      privateKey: ethers.Wallet.createRandom().privateKey,
+      privateKey: '',
       recoverySalt: {},
     }),
     {
@@ -59,4 +59,8 @@ export const updateProvider = () => {
   useProvider.setState(() => ({
     provider,
   }));
+};
+
+export const setAccountAndPK = (privateKey: string, account: string) => {
+  useLocalStore.setState(() => ({ privateKey, account }));
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3718,10 +3718,19 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bls-wallet-clients@0.8.2-77f1638:
-  version "0.8.2-77f1638"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-77f1638.tgz#61212aac502aed821bc6036cb95a2cdaa9c0b67e"
-  integrity sha512-2gTVHUvs4+/fBwgtcZCO+DsKTnJAiebYrpCUdygIqZaFeHdEyp6xU2F8ZT+XOcNoMeN1B9TT5EupV1RTvISFkQ==
+bls-wallet-clients@0.8.2-1452ef5:
+  version "0.8.2-1452ef5"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.2-1452ef5.tgz#d76e938ca45ec5da44c8e59699d1bd5f6c69dcd2"
+  integrity sha512-bg7WLr9NRbvDzj+zgkLNfaPzr1m0m13Cc8RJoZ2s6s+ic7WxSiwxTkZGc2SChFgmG8ZGi1O9DnR6//lrTsMVUA==
+  dependencies:
+    "@thehubbleproject/bls" "^0.5.1"
+    ethers "^5.7.2"
+    node-fetch "2.6.7"
+
+bls-wallet-clients@0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.8.3.tgz#7d3ee34ad3508ee730f3c4766980301bc3625d61"
+  integrity sha512-U5CQ7dZXIDmThu7spZyEhAgXyZ1FkamQk5jjV024L3egPr5zhenaeghdRqnjgp5YJ0PuxeFbe0c3SC5s42z7tQ==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"
@@ -5297,6 +5306,14 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
+
+ethdk@^0.0.0-beta.4:
+  version "0.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/ethdk/-/ethdk-0.0.0-beta.4.tgz#97e3859d481aa22b3e5e3212ff031fd5c60e293a"
+  integrity sha512-8yvt/3bHju9tH+/QCanmvI/GXH0mTQmN8QuFZjzRrTJuirbSYsuatDgiu8bq/iW/sr0YXdpHPtlGP8HSLi30UA==
+  dependencies:
+    bls-wallet-clients "0.8.2-1452ef5"
+    ethers "^5.7.2"
 
 ethers@^5.5.3:
   version "5.6.9"


### PR DESCRIPTION
Adding the ethdk node module to the browser wallet

If we want to completely remove the dependence of `ethers` from the browser wallet, there's a few more things we would need to support.

- Listening to block changes - `UseOnBlock.ts`
- `isAddress` function
- `toHexString()`
- `formatEther()`

Not sure if we really want to add all of this to ethdk

https://github.com/web3well/ethdk/issues/24